### PR TITLE
fix(demo): make sure home demo doesn't flicker

### DIFF
--- a/src/js/demos/homeDemo.ts
+++ b/src/js/demos/homeDemo.ts
@@ -53,7 +53,7 @@ homeUI.addWidgets(
             itemsList: `<ul>
                     {{#items}}
                     <li>
-                        <img src="{{metadata.img}}" height="40px">
+                        <img src="{{metadata.img}}" height="40px" width="40px">
                         <span class="ml-3">{{metadata.title}}</span>
                         <span style="color: #777777; font-size: .8rem">({{indexedMetadata.year}})</span>
                         {{#indexedMetadata.rating}}


### PR DESCRIPTION
By adding a width to it, you ensure that the text doesn't flicker

This is the current state if the user is on the page for the first time:
![2018-08-02 11_05_14](https://user-images.githubusercontent.com/6270048/43574239-f4fae624-9643-11e8-9a46-0c82061d2d81.gif)